### PR TITLE
Add nonvar cloud analysis monitoring script

### DIFF
--- a/scripts/parse_nonvar_cld_log.py
+++ b/scripts/parse_nonvar_cld_log.py
@@ -42,7 +42,7 @@ def parse_in_args(argv):
                         help='Log file from lightning.fd',
                         type=str)
 
-    parser.add_argument('--refmosiac',
+    parser.add_argument('--refmosaic',
                         dest='refmosaic_log',
                         default='missing',
                         help='Log file from refmosaic_nonvar.fd',
@@ -171,8 +171,8 @@ def parse_refmosaic(fname):
         for line in fptr:
             if 'level max min height' in line:
                 out['number'][0] = out['number'][0] + 1
-                out['number'][1] = max(out['number'][1], int(line.split()[-3]))
-                out['number'][2] = max(out['number'][2], int(line.split()[-2]))
+                out['number'][1] = max(out['number'][1], float(line.split()[-3]))
+                out['number'][2] = min(out['number'][2], float(line.split()[-2]))
 
     return out
 
@@ -264,8 +264,8 @@ def write_results(out_all, fname):
 
     """
 
-    with open(fname, 'r') as fptr:
-        tmpl = '{s1:>25}{s2:>25}{s3:>25}{s4:>25}'
+    with open(fname, 'w') as fptr:
+        tmpl = '{s1:>22}{s2:>25}{s3:>15}{s4:>15}\n'
         fptr.write(tmpl.format(s1='program', 
                                s2='observation', 
                                s3='number', 
@@ -274,7 +274,7 @@ def write_results(out_all, fname):
             fptr.write(tmpl.format(s1=out_all['program'][i],
                                    s2=out_all['observation'][i],
                                    s3=out_all['number'][i],
-                                   s4=out_all['status'][i])
+                                   s4=out_all['status'][i]))
 
 
 #

--- a/scripts/parse_nonvar_cld_log.py
+++ b/scripts/parse_nonvar_cld_log.py
@@ -27,31 +27,31 @@ def parse_in_args(argv):
     # Optional arguments
     parser.add_argument('--larccld',
                         dest='larccld_log',
-                        default='missing',
+                        default='nonvar_larccld.log',
                         help='Log file from larccld.fd',
                         type=str)
 
     parser.add_argument('--metarcld',
                         dest='metarcld_log',
-                        default='missing',
+                        default='nonvar_metarcld.log',
                         help='Log file from metarcld.fd',
                         type=str)
 
     parser.add_argument('--lightning',
                         dest='lightning_log',
-                        default='missing',
+                        default='nonvar_lightning.log',
                         help='Log file from lightning.fd',
                         type=str)
 
     parser.add_argument('--refmosaic',
                         dest='refmosaic_log',
-                        default='missing',
+                        default='nonvar_refmosaic.log',
                         help='Log file from refmosaic_nonvar.fd',
                         type=str)
 
     parser.add_argument('--cloudanalysis',
                         dest='cloudanalysis_log',
-                        default='missing',
+                        default='stdout_cloudanalysis',
                         help='Log file from cloudanalysis.fd',
                         type=str)
 

--- a/scripts/parse_nonvar_cld_log.py
+++ b/scripts/parse_nonvar_cld_log.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python
+# parse nonvar cloud analysis stats from the log file
+#
+import sys
+import re
+import argparse
+
+def parse_in_args(argv):
+    """
+    Parse input arguments
+
+    Parameters
+    ----------
+    argv : list
+        Command-line arguments from sys.argv[1:]
+    
+    Returns
+    -------
+    Parsed input arguments
+
+    """
+
+    parser = argparse.ArgumentParser(description='Script that plots parses output from nonvar cloud \
+                                                  analysis log files.')
+    
+    # Optional arguments
+    parser.add_argument('--larccld',
+                        dest='larccld_log',
+                        default='missing',
+                        help='Log file from larccld.fd',
+                        type=str)
+
+    parser.add_argument('--metarcld',
+                        dest='metarcld_log',
+                        default='missing',
+                        help='Log file from metarcld.fd',
+                        type=str)
+
+    parser.add_argument('--lightning',
+                        dest='lightning_log',
+                        default='missing',
+                        help='Log file from lightning.fd',
+                        type=str)
+
+    parser.add_argument('--refmosiac',
+                        dest='refmosaic_log',
+                        default='missing',
+                        help='Log file from refmosaic_nonvar.fd',
+                        type=str)
+
+    parser.add_argument('--cloudanalysis',
+                        dest='cloudanalysis_log',
+                        default='missing',
+                        help='Log file from cloudanalysis.fd',
+                        type=str)
+
+    return vars(parser.parse_args(argv))
+
+
+def parse_larccld(fname):
+    """
+    Parse log file for larccld.fd
+
+    Parameters
+    ----------
+    fname : string
+        Log file name
+
+    Returns
+    -------
+    Dictionary with information from log file
+
+    """
+
+    out = {'program': 2*['larccld.fd'],
+           'observation': ['GOES_EAST', 'GOES_WEST'],
+           'number': 2*[0],
+           'status': 2*['read']}
+
+    with open(fname, 'r') as fptr:
+        for line in fptr:
+            if 'east_time and number=' in line:
+                out['number'][0] = int(line.split()[-1])
+            elif 'west_time and number=' in line:
+                out['number'][1] = int(line.split()[-1])
+
+    return out
+
+
+def parse_metarcld(fname):
+    """
+    Parse log file for metarcld.fd
+
+    Parameters
+    ----------
+    fname : string
+        Log file name
+
+    Returns
+    -------
+    Dictionary with information from log file
+
+    """
+
+    out = {'program': 2*['metarcld.fd'],
+           'observation': ['raw_METAR', 'METAR_on_MPAS_mesh'],
+           'number': 2*[0],
+           'status': ['read', 'processed']}
+
+    with open(fname, 'r') as fptr:
+        for line in fptr:
+            if 'number of valid cloud obs =' in line:
+                out['number'][0] = int(line.split()[-1])
+            elif 'number of cloud on MPAS mesh=' in line:
+                out['number'][1] = int(line.split()[-1])
+
+    return out
+
+
+def parse_lightning(fname):
+    """
+    Parse log file for lightning.fd
+
+    Parameters
+    ----------
+    fname : string
+        Log file name
+
+    Returns
+    -------
+    Dictionary with information from log file
+
+    """
+
+    out = {'program': 2*['lightning.fd'],
+           'observation': ['raw_lightning', 'lightning_on_MPAS_mesh'],
+           'number': 2*[0],
+           'status': ['read', 'processed']}
+
+    with open(fname, 'r') as fptr:
+        for line in fptr:
+            if 'The total number of lightning obs is:' in line:
+                out['number'][0] = int(line.split()[-1])
+            elif 'Write out results for MPAS:' in line:
+                out['number'][1] = int(line.split()[-1])
+
+    return out
+
+
+def parse_refmosaic(fname):
+    """
+    Parse log file for refmosaic_nonvar.fd
+
+    Parameters
+    ----------
+    fname : string
+        Log file name
+
+    Returns
+    -------
+    Dictionary with information from log file
+
+    """
+
+    out = {'program': 3*['refmosaic_nonvar.fd'],
+           'observation': ['n_levels', 'max_val', 'min_val'],
+           'number': 3*[0],
+           'status': 3*['read']}
+
+    with open(fname, 'r') as fptr:
+        for line in fptr:
+            if 'level max min height' in line:
+                out['number'][0] = out['number'][0] + 1
+                out['number'][1] = max(out['number'][1], int(line.split()[-3]))
+                out['number'][2] = max(out['number'][2], int(line.split()[-2]))
+
+    return out
+
+
+def parse_cloudanalysis(fname):
+    """
+    Parse log file for cloudanalysis.fd
+
+    Parameters
+    ----------
+    fname : string
+        Log file name
+
+    Returns
+    -------
+    Dictionary with information from log file
+
+    """
+
+    out = {'program': 4*['cloudanalysis.fd'],
+           'observation': ['nasa_larc', 'METAR', 'lightning', 'refl'],
+           'number': 4*['N/A'],
+           'status': 4*['not_used']}
+
+    with open(fname, 'r') as fptr:
+        for line in fptr:
+            if 'gsdcloudanalysis: NASA LaRC cloud products are read in successfully' in line:
+                out['status'][0] = 'ingested'
+            elif 'gsdcloudanalysis: Surface cloud observations are read in successfully' in line:
+                out['status'][1] = 'ingested'
+            elif 'gsdcloudanalysis: Lightning is read in successfully' in line:
+                out['status'][2] = 'ingested'
+            elif 'gsdcloudanalysis: radar reflectivity is read in successfully' in line:
+                out['status'][3] = 'ingested'
+
+    return out
+
+
+def run_nonvar_parse_all(fnames):
+    """
+    Parse all nonvar cloud analysis log files
+
+    Parameters
+    ----------
+    fnames : dictionary
+        Nonvar cloud analysis log files
+
+    Returns
+    -------
+    Dictionary with all output from nonvar cloud analysis log files
+
+    """
+
+    fcts = {'larccld_log': parse_larccld,
+            'metarcld_log': parse_metarcld,
+            'lightning_log': parse_lightning,
+            'refmosaic_log': parse_refmosaic,
+            'cloudanalysis_log': parse_cloudanalysis}
+
+    out_all = {'program': [],
+               'observation': [],
+               'number': [],
+               'status': []}
+
+    for key in fcts:
+        if key in fnames:
+            if fnames[key] != 'missing':
+                out = fcts[key](fnames[key])
+                for field in out_all:
+                    out_all[field] = out_all[field] + out[field]
+
+    return out_all
+
+
+def write_results(out_all, fname):
+    """
+    Write results from parsing nonvar cloud analysis logs to a new file
+
+    Parameters
+    ----------
+    out_all : dictionary
+        Output from nonvar cloud analysis log files
+    fname : string
+        Output text file
+
+    Returns
+    -------
+    None
+
+    """
+
+    with open(fname, 'r') as fptr:
+        tmpl = '{s1:>25}{s2:>25}{s3:>25}{s4:>25}'
+        fptr.write(tmpl.format(s1='program', 
+                               s2='observation', 
+                               s3='number', 
+                               s4='status'))
+        for i in range(len(out_all['program'])):
+            fptr.write(tmpl.format(s1=out_all['program'][i],
+                                   s2=out_all['observation'][i],
+                                   s3=out_all['number'][i],
+                                   s4=out_all['status'][i])
+
+
+#
+# ***********************************************************************
+# !!  MAIN starts here !!
+# ***********************************************************************
+
+if __name__ == '__main__':
+
+    # Read in user inputs
+    param = parse_in_args(sys.argv[1:])
+    
+    # Run parser for each log file
+    out_all = run_nonvar_parse_all(param)
+
+    # Write out results
+    write_results(out_all, 'nonvar_cloud_out.txt')

--- a/scripts/parse_nonvar_cld_log.py
+++ b/scripts/parse_nonvar_cld_log.py
@@ -239,10 +239,12 @@ def run_nonvar_parse_all(fnames):
 
     for key in fcts:
         if key in fnames:
-            if fnames[key] != 'missing':
+            try:
                 out = fcts[key](fnames[key])
                 for field in out_all:
                     out_all[field] = out_all[field] + out[field]
+            except FileNotFoundError:
+                print(f"WARNING: File not found. Skipping {key}. File: {fnames[key]}")
 
     return out_all
 

--- a/scripts/parse_nonvar_cld_log.py
+++ b/scripts/parse_nonvar_cld_log.py
@@ -2,8 +2,8 @@
 # parse nonvar cloud analysis stats from the log file
 #
 import sys
-import re
 import argparse
+
 
 def parse_in_args(argv):
     """
@@ -13,7 +13,7 @@ def parse_in_args(argv):
     ----------
     argv : list
         Command-line arguments from sys.argv[1:]
-    
+
     Returns
     -------
     Parsed input arguments
@@ -23,7 +23,7 @@ def parse_in_args(argv):
     parser = argparse.ArgumentParser(description='Script that plots parses \
                                                   output from nonvar cloud \
                                                   analysis log files.')
-    
+
     # Optional arguments
     parser.add_argument('--larccld',
                         dest='larccld_log',
@@ -266,9 +266,9 @@ def write_results(out_all, fname):
 
     with open(fname, 'w') as fptr:
         tmpl = '{s1:>22}{s2:>25}{s3:>15}{s4:>15}\n'
-        fptr.write(tmpl.format(s1='program', 
-                               s2='observation', 
-                               s3='number', 
+        fptr.write(tmpl.format(s1='program',
+                               s2='observation',
+                               s3='number',
                                s4='status'))
         for i in range(len(out_all['program'])):
             fptr.write(tmpl.format(s1=out_all['program'][i],
@@ -286,7 +286,7 @@ if __name__ == '__main__':
 
     # Read in user inputs
     param = parse_in_args(sys.argv[1:])
-    
+
     # Run parser for each log file
     out_all = run_nonvar_parse_all(param)
 

--- a/scripts/parse_nonvar_cld_log.py
+++ b/scripts/parse_nonvar_cld_log.py
@@ -195,18 +195,27 @@ def parse_cloudanalysis(fname):
 
     out = {'program': 4*['cloudanalysis.fd'],
            'observation': ['nasa_larc', 'METAR', 'lightning', 'refl'],
-           'number': 4*['N/A'],
+           'number': 4*[0],
            'status': 4*['not_used']}
 
     with open(fname, 'r') as fptr:
         tmpl = 'gsdcloudanalysis: {obs} read in successfully'
-        for line in fptr:
-            for i, obs in enumerate(['NASA LaRC cloud products are',
+        contents = fptr.readlines()
+        for i, line in enumerate(contents):
+            if 'metar cloud=mta_cldmetarcld' in line:
+                out['number'][1] = int(contents[i+1].split()[1])
+            elif 'read in lightning from=' in line:
+                out['number'][2] = int(contents[i+1].split()[3])
+            elif 'ref_mosaic' in line:
+                out['number'][3] = out['number'][3] + 1
+            elif 'read NASA LaRC obs=' in line:
+                out['number'][0] = int(line.split()[-3])
+            for j, obs in enumerate(['NASA LaRC cloud products are',
                                      'Surface cloud observations are',
                                      'Lightning is',
                                      'radar reflectivity is']):
                 if tmpl.format(obs=obs) in line:
-                    out['status'][i] = 'ingested'
+                    out['status'][j] = 'ingested'
 
     return out
 

--- a/scripts/parse_nonvar_cld_log.py
+++ b/scripts/parse_nonvar_cld_log.py
@@ -20,7 +20,8 @@ def parse_in_args(argv):
 
     """
 
-    parser = argparse.ArgumentParser(description='Script that plots parses output from nonvar cloud \
+    parser = argparse.ArgumentParser(description='Script that plots parses \
+                                                  output from nonvar cloud \
                                                   analysis log files.')
     
     # Optional arguments
@@ -198,15 +199,14 @@ def parse_cloudanalysis(fname):
            'status': 4*['not_used']}
 
     with open(fname, 'r') as fptr:
+        tmpl = 'gsdcloudanalysis: {obs} read in successfully'
         for line in fptr:
-            if 'gsdcloudanalysis: NASA LaRC cloud products are read in successfully' in line:
-                out['status'][0] = 'ingested'
-            elif 'gsdcloudanalysis: Surface cloud observations are read in successfully' in line:
-                out['status'][1] = 'ingested'
-            elif 'gsdcloudanalysis: Lightning is read in successfully' in line:
-                out['status'][2] = 'ingested'
-            elif 'gsdcloudanalysis: radar reflectivity is read in successfully' in line:
-                out['status'][3] = 'ingested'
+            for i, obs in enumerate(['NASA LaRC cloud products are',
+                                     'Surface cloud observations are',
+                                     'Lightning is',
+                                     'radar reflectivity is']):
+                if tmpl.format(obs=obs) in line:
+                    out['status'][i] = 'ingested'
 
     return out
 

--- a/ush/drive.sh
+++ b/ush/drive.sh
@@ -19,16 +19,19 @@ export PYDAMONITOR=${HOMErrfs}/workflow/sideload/pyDAmonitor/scripts
 # Obtain unique process id (pid) and create the run directory (DATA).
 #-----------------------------------------------------------------------
 #
+export LOG_DIR=${COMROOT}/${NET}/${VERSION}/logs/${RUN}.${PDY}/${cyc}/${WGF}
 if [[ "${DO_SPINUP:-FALSE}" == "TRUE" ]];  then
   export WORKDIR=${COMOUT}/pyDAmonitor_spinup
   export JEDI_DIR=${COMOUT}/jedivar_spinup/${WGF}
   export NONVAR_CLD_DIR=${COMOUT}/nonvar_cldana_spinup/${WGF}
-  export LOG_DIR=???
+  export NONVAR_BUFR_LOG=${LOG_DIR}/rrfs_nonvar_bufrobs_spinup_${TAG}_${CDATE}.log
+  export NONVAR_REFL_LOG=${LOG_DIR}/rrfs_nonvar_reflobs_spinup_${TAG}_${CDATE}.log
 else
   export WORKDIR=${COMOUT}/pyDAmonitor
   export JEDI_DIR=${COMOUT}/jedivar/${WGF}
   export NONVAR_CLD_DIR=${COMOUT}/nonvar_cldana/${WGF}
-  export LOG_DIR=???
+  export NONVAR_BUFR_LOG=${LOG_DIR}/rrfs_nonvar_bufrobs_${TAG}_${CDATE}.log
+  export NONVAR_REFL_LOG=${LOG_DIR}/rrfs_nonvar_reflobs_${TAG}_${CDATE}.log
 fi
 mkdir -p "${WORKDIR}"
 cd "${WORKDIR}"
@@ -39,13 +42,15 @@ ln -snf ${PYDAMONITOR}/parse_jedi_log.py .
 ./parse_jedi_log.py
 #
 # parse the nonvar cloud analysis log files to get nonvar_cloud_out.txt
-ln -snf ${PYDAMONITOR}/parse_nonvar_cld_log.py .
-./parse_nonvar_cld_log.py \
-	--larccld ${LOG_DIR}/rrfs_nonvar_bufrobs_rrfsv2x_${CYC_TIME}.log \
-	--metarcld ${LOG_DIR}/rrfs_nonvar_bufrobs_rrfsv2x_${CYC_TIME}.log \
-	--lightning ${LOG_DIR}/rrfs_nonvar_bufrobs_rrfsv2x_${CYC_TIME}.log \
-	--refmosaic ${LOG_DIR}/rrfs_nonvar_reflobs_rrfsv2x_${CYC_TIME}.log \
-	--cloudanalysis ${NONVAR_CLD_DIR}/stdout_cloudanalysis.d0000
+if [[ "${DO_NONVAR_CLOUD_ANA:-FALSE}" == "TRUE" ]]; then
+  ln -snf ${NONVAR_BUFR_LOG} nonvar_larccld.log
+  ln -snf ${NONVAR_BUFR_LOG} nonvar_metarcld.log
+  ln -snf ${NONVAR_BUFR_LOG} nonvar_lightning.log
+  ln -snf ${NONVAR_REFL_LOG} nonvar_refmosaic.log
+  ln -snf ${NONVAR_CLD_DIR}/stdout_cloudanalysis.d0000 stdout_cloudanalysis
+  ln -snf ${PYDAMONITOR}/parse_nonvar_cld_log.py .
+  ./parse_nonvar_cld_log.py
+fi
 #
 #
 date

--- a/ush/drive.sh
+++ b/ush/drive.sh
@@ -22,9 +22,13 @@ export PYDAMONITOR=${HOMErrfs}/workflow/sideload/pyDAmonitor/scripts
 if [[ "${DO_SPINUP:-FALSE}" == "TRUE" ]];  then
   export WORKDIR=${COMOUT}/pyDAmonitor_spinup
   export JEDI_DIR=${COMOUT}/jedivar_spinup/${WGF}
+  export NONVAR_CLD_DIR=${COMOUT}/nonvar_cldana_spinup/${WGF}
+  export LOG_DIR=???
 else
   export WORKDIR=${COMOUT}/pyDAmonitor
   export JEDI_DIR=${COMOUT}/jedivar/${WGF}
+  export NONVAR_CLD_DIR=${COMOUT}/nonvar_cldana/${WGF}
+  export LOG_DIR=???
 fi
 mkdir -p "${WORKDIR}"
 cd "${WORKDIR}"
@@ -33,6 +37,15 @@ ln -snf ${JEDI_DIR}/* .
 # parse the jedi log file to get minimization.txt and obs_counts.txt
 ln -snf ${PYDAMONITOR}/parse_jedi_log.py .
 ./parse_jedi_log.py
+#
+# parse the nonvar cloud analysis log files to get nonvar_cloud_out.txt
+ln -snf ${PYDAMONITOR}/parse_nonvar_cld_log.py .
+./parse_jedi_log.py \
+	--larccld ${LOG_DIR}/rrfs_nonvar_bufrobs_rrfsv2x_${CYC_TIME}.log \
+	--metarcld ${LOG_DIR}/rrfs_nonvar_bufrobs_rrfsv2x_${CYC_TIME}.log \
+	--lightning ${LOG_DIR}/rrfs_nonvar_bufrobs_rrfsv2x_${CYC_TIME}.log \
+	--refmosaic ${LOG_DIR}/rrfs_nonvar_reflobs_rrfsv2x_${CYC_TIME}.log \
+	--cloudanalysis ${NONVAR_CLD_DIR}/stdout_cloudanalysis.d0000
 #
 #
 date

--- a/ush/drive.sh
+++ b/ush/drive.sh
@@ -40,7 +40,7 @@ ln -snf ${PYDAMONITOR}/parse_jedi_log.py .
 #
 # parse the nonvar cloud analysis log files to get nonvar_cloud_out.txt
 ln -snf ${PYDAMONITOR}/parse_nonvar_cld_log.py .
-./parse_jedi_log.py \
+./parse_nonvar_cld_log.py \
 	--larccld ${LOG_DIR}/rrfs_nonvar_bufrobs_rrfsv2x_${CYC_TIME}.log \
 	--metarcld ${LOG_DIR}/rrfs_nonvar_bufrobs_rrfsv2x_${CYC_TIME}.log \
 	--lightning ${LOG_DIR}/rrfs_nonvar_bufrobs_rrfsv2x_${CYC_TIME}.log \


### PR DESCRIPTION
This PR adds a Python script for parsing log files produced by the various nonvariational cloud analysis programs:

- [larccld.fd](https://github.com/NOAA-GSL/RRFS_UTILS/tree/develop/larccld.fd)
- [metarcld.fd](https://github.com/NOAA-GSL/RRFS_UTILS/tree/develop/metarcld.fd)
- [lightning.fd](https://github.com/NOAA-GSL/RRFS_UTILS/tree/develop/lightning.fd)
- [refmosaic_nonvar.fd](https://github.com/NOAA-GSL/RRFS_UTILS/tree/develop/refmosaic_nonvar.fd)
- [cloudanalysis.fd](https://github.com/NOAA-GSL/RRFS_UTILS/tree/develop/cloudanalysis.fd)

Output can then be saved to a text file.

Currently this script is designed to be run by itself. @guoqing-noaa, what are your thoughts regarding integrating this with other parts of pyDAmonitor? It is quite a bit different from `parse_jedi_log.py`, so I'm wondering if the nonvar cloud analysis monitor should be called from a different script.