### PR TITLE
use different drive scripts for the `det` and `enkf` runs

### DIFF
--- a/ush/drive.sh
+++ b/ush/drive.sh
@@ -30,40 +30,16 @@ if [[ "${DO_SPINUP:-FALSE}" == "TRUE" ]];  then
 else
   export WORKDIR=${COMOUT}/pyDAmonitor/${WGF}
   export JEDI_DIR=${COMOUT}/jedivar/${WGF}
+  export GETKF_DIR=${COMOUT}/getkf/${WGF}
   export NONVAR_CLD_DIR=${COMOUT}/nonvar_cldana/${WGF}
   export NONVAR_BUFR_LOG=$(ls ${LOG_DIR}/rrfs_nonvar_bufrobs_*_${CDATE}.log | head -n 1)
   export NONVAR_REFL_LOG=$(ls ${LOG_DIR}/rrfs_nonvar_reflobs_*_${CDATE}.log | head -n 1)
 fi
 mkdir -p "${WORKDIR}"
 cd "${WORKDIR}"
-ln -snf ${JEDI_DIR}/* .
 #
-# parse the jedi log file to get minimization.txt and obs_counts.txt
-ln -snf ${PYDAMONITOR}/scripts/parse_jedi_log.py .
-./parse_jedi_log.py
 #
-# parse the nonvar cloud analysis log files to get nonvar_cloud_out.txt
-if [[ "${DO_NONVAR_CLOUD_ANA:-FALSE}" == "TRUE" ]]; then
-  ln -snf ${NONVAR_BUFR_LOG} nonvar_larccld.log
-  ln -snf ${NONVAR_BUFR_LOG} nonvar_metarcld.log
-  ln -snf ${NONVAR_BUFR_LOG} nonvar_lightning.log
-  ln -snf ${NONVAR_REFL_LOG} nonvar_refmosaic.log
-  ln -snf ${NONVAR_CLD_DIR}/stdout_cloudanalysis.d0000 stdout_cloudanalysis
-  ln -snf ${PYDAMONITOR}/scripts/parse_nonvar_cld_log.py .
-  ./parse_nonvar_cld_log.py
-fi
-#
-# plot the cost/grad descent lines
-ln -snf ${PYDAMONITOR}/scripts/costgrad_descent.py .
-./costgrad_descent.py
-#
-# plot the time series of obs counts
-ln -snf ${PYDAMONITOR}/scripts/obs_count_timeseries.py .
-./obs_count_timeseries.py ${CDATE} 10  # plot 10 days of obs counts
-#
-# prep files for web
-ln -snf ${PYDAMONITOR}/ush/prep_web.sh .
-./prep_web.sh
+${PYDAMONITOR}/ush/drive_${WGF}.sh
 #
 #
 touch pyDAmonitor.done

--- a/ush/drive_det.sh
+++ b/ush/drive_det.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+declare -rx PS4='+${SECONDS}s $(basename ${BASH_SOURCE[0]:-${FUNCNAME[0]:-"Unknown"}})[${LINENO}]${id}: '
+set -x
+#
+#------------------------------------------------------------------------------------------------
+# Note for offline debug: export JEDI_DIR, PYDAMONITOR, CDATE, etc
+# and then run this script
+#------------------------------------------------------------------------------------------------
+
+ln -snf ${JEDI_DIR}/* .
+#
+# parse the jedi log file to get minimization.txt and obs_counts.txt
+ln -snf ${PYDAMONITOR}/scripts/parse_jedi_log.py .
+./parse_jedi_log.py
+#
+# parse the nonvar cloud analysis log files to get nonvar_cloud_out.txt
+if [[ "${DO_NONVAR_CLOUD_ANA:-FALSE}" == "TRUE" ]]; then
+  ln -snf ${NONVAR_BUFR_LOG} nonvar_larccld.log
+  ln -snf ${NONVAR_BUFR_LOG} nonvar_metarcld.log
+  ln -snf ${NONVAR_BUFR_LOG} nonvar_lightning.log
+  ln -snf ${NONVAR_REFL_LOG} nonvar_refmosaic.log
+  ln -snf ${NONVAR_CLD_DIR}/stdout_cloudanalysis.d0000 stdout_cloudanalysis
+  ln -snf ${PYDAMONITOR}/scripts/parse_nonvar_cld_log.py .
+  ./parse_nonvar_cld_log.py
+fi
+#
+# plot the cost/grad descent lines
+ln -snf ${PYDAMONITOR}/scripts/costgrad_descent.py .
+./costgrad_descent.py
+#
+# plot the time series of obs counts
+ln -snf ${PYDAMONITOR}/scripts/obs_count_timeseries.py .
+./obs_count_timeseries.py ${CDATE} 10  # plot 10 days of obs counts
+#
+# prep files for web
+ln -snf ${PYDAMONITOR}/ush/prep_web_det.sh .
+./prep_web_det.sh
+#

--- a/ush/drive_enkf.sh
+++ b/ush/drive_enkf.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+declare -rx PS4='+${SECONDS}s $(basename ${BASH_SOURCE[0]:-${FUNCNAME[0]:-"Unknown"}})[${LINENO}]${id}: '
+set -x
+#
+#------------------------------------------------------------------------------------------------
+# Note for offline debug: export GETKF_DIR, PYDAMONITOR, CDATE, etc
+# and then run this script
+#------------------------------------------------------------------------------------------------
+
+ln -snf ${GETKF_DIR}/* .

--- a/ush/prep_web_det.sh
+++ b/ush/prep_web_det.sh
@@ -5,8 +5,7 @@ set -x
 
 mkdir -p web
 cd web
-sed -e "s/2024050600/${PDY}${cyc}/g" ${PYDAMONITOR}/ush/index.html_cycle > index.html
-cp ${PYDAMONITOR}/ush/yaml_peek.html .
+sed -e "s/2024050600/${CDATE}/g" ${PYDAMONITOR}/ush/index.html_cycle > index.html
 mv ../*.png .
 mv ../*.txt .
 ln -snfr *.txt ..  # link a copy to the parent directory

--- a/ush/prep_web_enkf.sh
+++ b/ush/prep_web_enkf.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# prep all files needed by the webpage
+declare -rx PS4='+${SECONDS}s $(basename ${BASH_SOURCE[0]:-${FUNCNAME[0]:-"Unknown"}})[${LINENO}]${id}: '
+set -x
+
+mkdir -p web
+cd web
+sed -e "s/2024050600/${CDATE}/g" ${PYDAMONITOR}/ush/index.html_cycle_enkf > index.html
+mv ../*.png .
+mv ../*.txt .
+ln -snfr *.txt ..  # link a copy to the parent directory
+cp -L ../log.*out .
+cp -L ../getkf.yaml .


### PR DESCRIPTION
@spanNOAA has been working on adding pyDAmonitor results for the ensemble system.

It is desirable to use different drive scripts for the `det` and `enkf` runs 