### PR TITLE
Add JEDI satellite data impact initial capability

### DIFF
--- a/scripts/data_impact_functions.py
+++ b/scripts/data_impact_functions.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import pickle
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def compute_bins(data):
+    """
+    Compute histogram bins based on data spread.
+    """
+
+    data = np.asarray(data)
+
+    if len(data) == 0:
+        return np.arange(-1, 1.1, 0.1)
+
+    std = np.std(data)
+
+    if std == 0 or not np.isfinite(std):
+        return np.linspace(
+            np.min(data) - 1,
+            np.max(data) + 1,
+            20
+        )
+
+    xmin = -4.0 * std
+    xmax = 4.0 * std
+
+    binsize = (np.max(data) - np.min(data)) / np.sqrt(len(data))
+
+    if binsize <= 0 or not np.isfinite(binsize):
+        binsize = std / 20.0
+
+    return np.arange(xmin, xmax + binsize, binsize)
+
+
+def plot_jo_histogram(
+    sensor,
+    CDATE,
+    jo_diffs,
+    obserr,
+    count_total,
+    count_assim,
+    count_large,
+    count_zero,
+    output_dir="./figures"
+):
+    """
+    Plot Jo-diff histogram for one sensor.
+    """
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    jo_diffs = np.asarray(jo_diffs)
+    obserr = np.asarray(obserr)
+
+    if len(jo_diffs) == 0:
+        print(f"[WARN] No Jo-diff values for {sensor}")
+        return
+
+    bins = compute_bins(jo_diffs)
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+
+    ax.hist(
+        jo_diffs,
+        bins=bins,
+        edgecolor="black"
+    )
+
+    ax.set_xlabel("Jo Diff")
+    ax.set_ylabel("Count")
+    ax.set_title(
+        f"{sensor} {CDATE}",
+        fontsize=14
+    )
+
+    ax.grid(True)
+
+    # ------------------------------------------
+    # Statistics
+    # ------------------------------------------
+    mean_jo = np.mean(jo_diffs)
+    sum_jo = np.sum(jo_diffs)
+    max_abs_jo = np.max(np.abs(jo_diffs))
+
+    valid_obserr = (
+        np.isfinite(obserr) &
+        (obserr > 0)
+    )
+
+    inv_obs_error = 1.0 / obserr[valid_obserr]
+
+    text = (
+        f"Total Obs Size = {count_total}\n"
+        f"Assim Obs Size = {count_assim}\n"
+        f"Mean Jo-diff = {mean_jo:.4f}\n"
+        f"Sum Jo-diff = {sum_jo:.4f}\n"
+        f"Max Abs Jo-diff = {max_abs_jo:.4f}\n"
+        f"|Jo-diff| > 25 = {count_large}\n"
+        f"Jo-diff = 0 = {count_zero}\n"
+        f"Mean Inv ObsErr = {np.mean(inv_obs_error):.4f}\n"
+        f"STD Inv ObsErr = {np.std(inv_obs_error):.4f}"
+    )
+
+    ax.text(
+        0.66,
+        0.95,
+        text,
+        transform=ax.transAxes,
+        verticalalignment="top",
+        fontsize=11
+    )
+
+    output_file = os.path.join(
+        output_dir,
+        f"{sensor}-{CDATE}.png"
+    )
+
+    plt.savefig(
+        output_file,
+        dpi=200,
+        bbox_inches="tight"
+    )
+
+    plt.close()
+
+    print(f"[SAVE] Figure: {output_file}")
+
+
+def save_legacy_pickle(
+    sensor_types,
+    final_total_size,
+    final_assim_size,
+    final_mean_jo_diff,
+    final_sum_jo_diff,
+    final_max_abs_jo_diff,
+    CDATE,
+    label="sate",
+    output_dir="./pickle"
+):
+    """
+    Save summary statistics using the legacy data-impact
+    pickle structure.
+    """
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    output_file = os.path.join(
+        output_dir,
+        f"{CDATE}_{label}.pkl"
+    )
+
+    output = [
+        sensor_types,
+        final_total_size,
+        final_assim_size,
+        final_mean_jo_diff,
+        final_sum_jo_diff,
+        final_max_abs_jo_diff
+    ]
+
+    with open(output_file, "wb") as f:
+        pickle.dump(
+            output,
+            f,
+            protocol=pickle.HIGHEST_PROTOCOL
+        )
+
+    print(f"[SAVE] Summary pickle: {output_file}")

--- a/scripts/data_impact_sate.py
+++ b/scripts/data_impact_sate.py
@@ -121,9 +121,14 @@ def analyze_sate(CDATE):
         # ----------------------------------------------------
         # Statistics
         # ----------------------------------------------------
-        mean_jo_diff = np.mean(jo_diffs)
-        sum_jo_diff = np.sum(jo_diffs)
-        max_abs_jo_diff = np.max(np.abs(jo_diffs))
+if jo_diffs.size:
+            mean_jo_diff = np.mean(jo_diffs)
+            sum_jo_diff = np.sum(jo_diffs)
+            max_abs_jo_diff = np.max(np.abs(jo_diffs))
+        else:
+            mean_jo_diff = np.nan
+            sum_jo_diff = 0.0
+            max_abs_jo_diff = np.nan
 
         print()
         print(f"Mean Jo-diff:    {mean_jo_diff}")

--- a/scripts/data_impact_sate.py
+++ b/scripts/data_impact_sate.py
@@ -54,8 +54,8 @@ def analyze_sate(CDATE):
 
         omb = ncd.groups["ombg"].variables["brightnessTemperature"][:]
         oma = ncd.groups["oman"].variables["brightnessTemperature"][:]
-        obserr = ncd.groups["EffectiveError0"].variables["brightnessTemperature"][:]
-        qc = ncd.groups["EffectiveQC0"].variables["brightnessTemperature"][:]
+        obserr = ncd.groups["EffectiveError1"].variables["brightnessTemperature"][:]
+        qc = ncd.groups["EffectiveQC1"].variables["brightnessTemperature"][:]
 
         channel = ncd.variables["Channel"][:]
 

--- a/scripts/data_impact_sate.py
+++ b/scripts/data_impact_sate.py
@@ -23,7 +23,14 @@ def analyze_sate(CDATE):
     # ------------------------------------------------------------
     # Choose sensors: comment/uncomment as needed
     # ------------------------------------------------------------
-    sensor_types = ['cris-fsr_n20']
+    sensor_types = [
+        "atms_n20",
+        "abi_g16",
+        "abi_g18",
+        "atms_n21",
+        "cris-fsr_n20",
+        "cris-fsr_n21"
+    ]
     
     n_sensor = len(sensor_types)
     final_total_size = np.zeros(n_sensor)

--- a/scripts/data_impact_sate.py
+++ b/scripts/data_impact_sate.py
@@ -121,7 +121,7 @@ def analyze_sate(CDATE):
         # ----------------------------------------------------
         # Statistics
         # ----------------------------------------------------
-if jo_diffs.size:
+        if jo_diffs.size:
             mean_jo_diff = np.mean(jo_diffs)
             sum_jo_diff = np.sum(jo_diffs)
             max_abs_jo_diff = np.max(np.abs(jo_diffs))

--- a/scripts/data_impact_sate.py
+++ b/scripts/data_impact_sate.py
@@ -3,12 +3,7 @@
 #
 import sys
 import os
-from datetime import datetime, timedelta
-import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
-import matplotlib.dates as mdates
-import pickle
 import netCDF4 as nc
 
 
@@ -17,8 +12,8 @@ from data_impact_functions import (
     save_legacy_pickle
 )
 
+
 def analyze_sate(CDATE):
-    dateEnd = datetime.strptime(CDATE, "%Y%m%d%H")
 
     # ------------------------------------------------------------
     # Choose sensors: comment/uncomment as needed
@@ -31,45 +26,44 @@ def analyze_sate(CDATE):
         "cris-fsr_n20",
         "cris-fsr_n21"
     ]
-    
+
     n_sensor = len(sensor_types)
     final_total_size = np.zeros(n_sensor)
     final_assim_size = np.zeros(n_sensor)
     final_mean_jo_diff = np.zeros(n_sensor)
     final_sum_jo_diff = np.zeros(n_sensor)
     final_max_abs_jo_diff = np.zeros(n_sensor)
-    
-    
-    for ss, sensor in enumerate(sensor_types):  
- 
+
+    for ss, sensor in enumerate(sensor_types):
+
         print(ss)
         print(sensor)
-        
+
         ncd = nc.Dataset(f"./jdiag_{sensor}.nc", 'r')
-        
+
         print(f"=== Processing {sensor} ===")
-        
+
         # NetCDF global attributes
         # --------------------------
         nc_attrs = ncd.ncattrs()
         print('NetCDF Global Attributes: ')
         print('nc_attrs = ', nc_attrs)
-        
+
         for nc_attr in nc_attrs:
             print('nc_attr', ncd.getncattr(nc_attr))
-    
+
         omb = ncd.groups["ombg"].variables["brightnessTemperature"][:]
-        oma = ncd.groups["oman"].variables["brightnessTemperature"][:]    
+        oma = ncd.groups["oman"].variables["brightnessTemperature"][:]
         obserr = ncd.groups["EffectiveError0"].variables["brightnessTemperature"][:]
         qc = ncd.groups["EffectiveQC0"].variables["brightnessTemperature"][:]
-                
+
         channel = ncd.variables["Channel"][:]
 
         print(f"OMB shape:    {omb.shape}")
         print(f"OMA shape:    {oma.shape}")
         print(f"ObsErr shape: {obserr.shape}")
         print(f"QC shape:     {qc.shape}")
-            
+
         # ----------------------------------------------------
         # Convert masked arrays to regular arrays with NaN
         # ----------------------------------------------------
@@ -105,7 +99,7 @@ def analyze_sate(CDATE):
         # ----------------------------------------------------
         jo_diff = np.full(omb.shape, np.nan)
 
-        jo_diff[valid] = ( oma[valid] ** 2 - omb[valid] ** 2) / ( obserr[valid] ** 2)
+        jo_diff[valid] = (oma[valid] ** 2 - omb[valid] ** 2) / (obserr[valid] ** 2)
 
         jo_diffs = jo_diff[valid]
 
@@ -135,8 +129,7 @@ def analyze_sate(CDATE):
         print(f"Mean Jo-diff:    {mean_jo_diff}")
         print(f"Sum Jo-diff:     {sum_jo_diff}")
         print(f"Max |Jo-diff|:   {max_abs_jo_diff}")
-            
-            
+
         # ----------------------------------------------------
         # Save summary arrays
         # ----------------------------------------------------
@@ -194,7 +187,7 @@ def analyze_sate(CDATE):
             final_max_abs_jo_diff,
             CDATE,
             label="sate"
-        )    
+        )
 
     # ------------------------------------------------------------
     # Final sensor summary
@@ -216,8 +209,6 @@ def analyze_sate(CDATE):
         )
 
 
-            
-            
 if __name__ == "__main__":
     #
     args = sys.argv
@@ -225,8 +216,8 @@ if __name__ == "__main__":
     if nargs < 1 or len(sys.argv[1]) < 10:
         print(f'Usage: {os.path.basename(sys.argv[0])} <YYYYMMDDHH>')
         sys.exit(1)
-        
+
     # ~~~~~~
     CDATE = sys.argv[1]
-            
+
     analyze_sate(CDATE)

--- a/scripts/data_impact_sate.py
+++ b/scripts/data_impact_sate.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python
+# compute the summary in the past 7 days, 30 days
+#
+import sys
+import os
+from datetime import datetime, timedelta
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+import pickle
+import netCDF4 as nc
+
+
+from data_impact_functions import (
+    plot_jo_histogram,
+    save_legacy_pickle
+)
+
+def analyze_sate(CDATE):
+    dateEnd = datetime.strptime(CDATE, "%Y%m%d%H")
+
+    # ------------------------------------------------------------
+    # Choose sensors: comment/uncomment as needed
+    # ------------------------------------------------------------
+    sensor_types = ['cris-fsr_n20']
+    
+    n_sensor = len(sensor_types)
+    final_total_size = np.zeros(n_sensor)
+    final_assim_size = np.zeros(n_sensor)
+    final_mean_jo_diff = np.zeros(n_sensor)
+    final_sum_jo_diff = np.zeros(n_sensor)
+    final_max_abs_jo_diff = np.zeros(n_sensor)
+    
+    
+    for ss, sensor in enumerate(sensor_types):  
+ 
+        print(ss)
+        print(sensor)
+        
+        ncd = nc.Dataset(f"./jdiag_{sensor}.nc", 'r')
+        
+        print(f"=== Processing {sensor} ===")
+        
+        # NetCDF global attributes
+        # --------------------------
+        nc_attrs = ncd.ncattrs()
+        print('NetCDF Global Attributes: ')
+        print('nc_attrs = ', nc_attrs)
+        
+        for nc_attr in nc_attrs:
+            print('nc_attr', ncd.getncattr(nc_attr))
+    
+        omb = ncd.groups["ombg"].variables["brightnessTemperature"][:]
+        oma = ncd.groups["oman"].variables["brightnessTemperature"][:]    
+        obserr = ncd.groups["EffectiveError0"].variables["brightnessTemperature"][:]
+        qc = ncd.groups["EffectiveQC0"].variables["brightnessTemperature"][:]
+                
+        channel = ncd.variables["Channel"][:]
+
+        print(f"OMB shape:    {omb.shape}")
+        print(f"OMA shape:    {oma.shape}")
+        print(f"ObsErr shape: {obserr.shape}")
+        print(f"QC shape:     {qc.shape}")
+            
+        # ----------------------------------------------------
+        # Convert masked arrays to regular arrays with NaN
+        # ----------------------------------------------------
+        omb = np.ma.filled(omb, np.nan)
+        oma = np.ma.filled(oma, np.nan)
+        obserr = np.ma.filled(obserr, np.nan)
+
+        # QC is integer; fill masked values with a bad-QC value
+        qc = np.ma.filled(qc, 999)
+
+        # ----------------------------------------------------
+        # Select assimilated observations
+        #
+        # EffectiveQC == 0 means used/accepted
+        # ----------------------------------------------------
+        valid = (
+            (qc == 0) &
+            np.isfinite(omb) &
+            np.isfinite(oma) &
+            np.isfinite(obserr) &
+            (obserr > 0)
+        )
+
+        # ----------------------------------------------------
+        # Jo difference
+        #
+        # Jo = (O-H)^2 / sigma_o^2
+        #
+        # Delta Jo = Jo_analysis - Jo_background
+        #
+        # Negative Jo-diff means the analysis moved
+        # the model closer to the observations.
+        # ----------------------------------------------------
+        jo_diff = np.full(omb.shape, np.nan)
+
+        jo_diff[valid] = ( oma[valid] ** 2 - omb[valid] ** 2) / ( obserr[valid] ** 2)
+
+        jo_diffs = jo_diff[valid]
+
+        # ----------------------------------------------------
+        # Counts
+        # ----------------------------------------------------
+        count_total = omb.size
+        count_assim = np.sum(valid)
+
+        count_large = np.sum(np.abs(jo_diffs) > 25)
+        count_zero = np.sum(jo_diffs == 0)
+
+        print()
+        print(f"Total elements:           {count_total}")
+        print(f"Assimilated elements:     {count_assim}")
+        print(f"|Jo-diff| > 25 count:     {count_large}")
+        print(f"Jo-diff == 0 count:       {count_zero}")
+
+        # ----------------------------------------------------
+        # Statistics
+        # ----------------------------------------------------
+        mean_jo_diff = np.mean(jo_diffs)
+        sum_jo_diff = np.sum(jo_diffs)
+        max_abs_jo_diff = np.max(np.abs(jo_diffs))
+
+        print()
+        print(f"Mean Jo-diff:    {mean_jo_diff}")
+        print(f"Sum Jo-diff:     {sum_jo_diff}")
+        print(f"Max |Jo-diff|:   {max_abs_jo_diff}")
+            
+            
+        # ----------------------------------------------------
+        # Save summary arrays
+        # ----------------------------------------------------
+        final_total_size[ss] = count_total
+        final_assim_size[ss] = count_assim
+        final_mean_jo_diff[ss] = mean_jo_diff
+        final_sum_jo_diff[ss] = sum_jo_diff
+        final_max_abs_jo_diff[ss] = max_abs_jo_diff
+
+        # ----------------------------------------------------
+        # Plot Jo-diff histogram
+        # ----------------------------------------------------
+        plot_jo_histogram(
+            sensor,
+            CDATE,
+            jo_diffs,
+            obserr[valid],
+            count_total,
+            count_assim,
+            count_large,
+            count_zero
+        )
+
+        # ----------------------------------------------------
+        # Optional: print statistics by channel
+        # ----------------------------------------------------
+        print()
+        print("Channel statistics:")
+
+        for ich, ch in enumerate(channel):
+
+            valid_ch = valid[:, ich]
+
+            if np.sum(valid_ch) == 0:
+                continue
+
+            jo_ch = jo_diff[:, ich][valid_ch]
+
+            print(
+                f"Channel {int(ch):5d}: "
+                f"N={len(jo_ch):5d} "
+                f"mean={np.mean(jo_ch):10.4f} "
+                f"sum={np.sum(jo_ch):12.4f}"
+            )
+
+        # ------------------------------------------------------------
+        # Save summary pickle
+        # ------------------------------------------------------------
+        save_legacy_pickle(
+            sensor_types,
+            final_total_size,
+            final_assim_size,
+            final_mean_jo_diff,
+            final_sum_jo_diff,
+            final_max_abs_jo_diff,
+            CDATE,
+            label="sate"
+        )    
+
+    # ------------------------------------------------------------
+    # Final sensor summary
+    # ------------------------------------------------------------
+    print()
+    print("====================================================")
+    print("Final Summary")
+    print("====================================================")
+
+    for ss, sensor in enumerate(sensor_types):
+
+        print(
+            f"{sensor:20s} "
+            f"total={final_total_size[ss]:10.0f} "
+            f"assim={final_assim_size[ss]:10.0f} "
+            f"mean={final_mean_jo_diff[ss]:12.5f} "
+            f"sum={final_sum_jo_diff[ss]:12.5f} "
+            f"maxabs={final_max_abs_jo_diff[ss]:12.5f}"
+        )
+
+
+            
+            
+if __name__ == "__main__":
+    #
+    args = sys.argv
+    nargs = len(args) - 1
+    if nargs < 1 or len(sys.argv[1]) < 10:
+        print(f'Usage: {os.path.basename(sys.argv[0])} <YYYYMMDDHH>')
+        sys.exit(1)
+        
+    # ~~~~~~
+    CDATE = sys.argv[1]
+            
+    analyze_sate(CDATE)

--- a/ush/drive_det.sh
+++ b/ush/drive_det.sh
@@ -33,8 +33,10 @@ ln -snf ${PYDAMONITOR}/scripts/obs_count_timeseries.py .
 ./obs_count_timeseries.py ${CDATE} 10  # plot 10 days of obs counts
 #
 # prep for data impact
+ln -snf ${PYDAMONITOR}/scripts/data_impact_conv.py .
 ln -snf ${PYDAMONITOR}/scripts/data_impact_sate.py .
 ln -snf ${PYDAMONITOR}/scripts/data_impact_functions.py .
+./data_impact_conv.py ${CDATE} 
 ./data_impact_sate.py ${CDATE} 
 
 ln -snf ${PYDAMONITOR}/ush/prep_data_impact_det.sh .

--- a/ush/drive_det.sh
+++ b/ush/drive_det.sh
@@ -32,6 +32,14 @@ ln -snf ${PYDAMONITOR}/scripts/costgrad_descent.py .
 ln -snf ${PYDAMONITOR}/scripts/obs_count_timeseries.py .
 ./obs_count_timeseries.py ${CDATE} 10  # plot 10 days of obs counts
 #
+# prep for data impact
+ln -snf ${PYDAMONITOR}/scripts/data_impact_sate.py .
+ln -snf ${PYDAMONITOR}/scripts/data_impact_functions.py .
+./data_impact_sate.py ${CDATE} 
+
+ln -snf ${PYDAMONITOR}/ush/prep_data_impact_det.sh .
+./prep_data_impact_det.sh
+# 
 # prep files for web
 ln -snf ${PYDAMONITOR}/ush/prep_web_det.sh .
 ./prep_web_det.sh

--- a/ush/prep_data_impact_det.sh
+++ b/ush/prep_data_impact_det.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# prep all files needed by the webpage
+declare -rx PS4='+${SECONDS}s $(basename ${BASH_SOURCE[0]:-${FUNCNAME[0]:-"Unknown"}})[${LINENO}]${id}: '
+set -x
+
+mkdir -p data_impact
+cd data_impact
+
+mv ../figures .
+mv ../pickle .
+
+
+
+

--- a/ush/prep_data_impact_det.sh
+++ b/ush/prep_data_impact_det.sh
@@ -3,11 +3,19 @@
 declare -rx PS4='+${SECONDS}s $(basename ${BASH_SOURCE[0]:-${FUNCNAME[0]:-"Unknown"}})[${LINENO}]${id}: '
 set -x
 
-mkdir -p data_impact
-cd data_impact
+mkdir -p data_impact/figures
+mkdir -p data_impact/pickle
 
-mv ../figures .
-mv ../pickle .
+# Move newly generated files into data_impact
+if [ -d figures ]; then
+    mv figures/* data_impact/figures/
+    rmdir figures
+fi
+
+if [ -d pickle ]; then
+    mv pickle/* data_impact/pickle/
+    rmdir pickle
+fi
 
 
 


### PR DESCRIPTION
This PR adds a JEDI-based satellite data impact workflow.

Changes include:
- add satellite Jo-diff calculations using OMB, OMA, EffectiveError, and EffectiveQC from jdiag files
- add shared plotting and pickle utilities
- add a preprocessing script for data impact diagnostics
- update the deterministic driver to support the data impact workflow

Initial testing was performed with CrIS-FSR N20 diagnostics.

The workflow also generates channel-level statistics and saves:
- Jo-diff histogram figures
- summary pickle files

Sample output and figure:

```
OMB shape:    (8816, 431)
OMA shape:    (8816, 431)
ObsErr shape: (8816, 431)
QC shape:     (8816, 431)

Total elements:           3799696
Assimilated elements:     72456
|Jo-diff| > 25 count:     5356
Jo-diff == 0 count:       0

Mean Jo-diff:    4.872523624073365
Sum Jo-diff:     353043.57170585974
Max |Jo-diff|:   107.58084106445312

Final Summary:
cris-fsr_n20 total=3799696 assim=72456 mean=4.87252 sum=353043.57171 maxabs=107.58084
```





<img width="1736" height="1097" alt="cris-fsr_n20-2024052719" src="https://github.com/user-attachments/assets/3a5a15a9-e88f-4eaa-a67d-3c9a56f78570" />
